### PR TITLE
Version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,21 @@ Removes source files, then pushes a commit to the release branch.
 
 ## Inputs
 
-### `release_branch`
-
-**Optional** Release branch name. Default: `"dist"`.
-
-## Environment Variables
-
-### `GITHUB_EMAIL`
+### `email`
 
 **Required** Email address to associate with the release commit.
 
-### `GITHUB_USERNAME`
+### `username`
 
 **Required** GitHub username to associate with the release commit.
 
-### `GITHUB_TOKEN`
+### `token`
 
 **Optional** A [GitHub token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the `repo` scope, or with the `contents: write` fine-grained permission. By default, [`token` from the `github` context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) is used, but this [GitHub Actions-provided token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) is scoped to the repo containing your workflow. If you are releasing another repo, you must provide `GITHUB_TOKEN`.
+
+### `release_branch`
+
+**Optional** Release branch name. Default: `"dist"`.
 
 ## Example usage
 
@@ -28,8 +26,6 @@ Removes source files, then pushes a commit to the release branch.
 - name: Update release branch
   uses: smockle/action-release-branch@main
   with:
-    release_branch: "dist"
-  env:
-    GITHUB_EMAIL: ${{ secrets.GH_EMAIL }}
-    GITHUB_USERNAME: ${{ secrets.GH_USERNAME }}
+    email: ${{ secrets.EMAIL }}
+    username: ${{ secrets.USERNAME }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,16 @@ name: "action-release-branch"
 author: "smockle"
 description: "Removes source files, then pushes a commit to the release branch."
 inputs:
+  email:
+    description: "Email address to associate with the release commit."
+    required: true
+  username:
+    description: "GitHub username to associate with the release commit."
+    required: true
+  token:
+    description: "A GitHub token with the `repo` scope, or with the `contents: write` fine-grained permission. Defaults to 'github.token'."
+    required: false
+    default: ${{ github.token }}
   release_branch:
     description: "Release branch name. Defaults to 'dist'."
     required: false
@@ -10,6 +20,9 @@ runs:
   using: "docker"
   image: "Dockerfile"
   args:
+    - ${{ inputs.email }}
+    - ${{ inputs.username }}
+    - ${{ inputs.token }}
     - ${{ inputs.release_branch }}
 branding:
   icon: "package"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,13 @@
 # and https://github.com/actions/typescript-action#publish-to-a-distribution-branch
 set -eo pipefail
 
-pwd
-ls -ltra
+# Fix 'fatal: not in a git directory'.
+# Details:
+# - https://github.com/actions/checkout/issues/363
+# - https://github.com/actions/checkout/issues/766
 git config --global --add safe.directory "$(realpath .)"
 
+# Set variables from action inputs.
 GITHUB_EMAIL="${1}"
 GITHUB_USERNAME="${2}"
 GITHUB_TOKEN="${3}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,10 @@ pwd
 ls -ltra
 git config --global --add safe.directory "$(realpath .)"
 
-RELEASE_BRANCH="${1:-dist}"
+GITHUB_EMAIL="${1}"
+GITHUB_USERNAME="${2}"
+GITHUB_TOKEN="${3}"
+RELEASE_BRANCH="${4}"
 
 # Set the user name and email to match the API token holder
 # This will make sure the git commits will have the correct photo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ set -eo pipefail
 
 pwd
 ls -ltra
+git config --global --add safe.directory "$(realpath .)"
 
 RELEASE_BRANCH="${1:-dist}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,9 @@
 # and https://github.com/actions/typescript-action#publish-to-a-distribution-branch
 set -eo pipefail
 
+pwd
+ls -ltra
+
 RELEASE_BRANCH="${1:-dist}"
 
 # Set the user name and email to match the API token holder


### PR DESCRIPTION
* Fixes `fatal: not in a git directory` by adding `git config --global --add safe.directory "$(realpath .)"`
* Fixes `fatal: empty ident name (for <>) not allowed` by propagating data using inputs instead of environment variables